### PR TITLE
Updated to fix array_get() and str_after() obsoletions

### DIFF
--- a/src/MultiformatServiceProvider.php
+++ b/src/MultiformatServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class MultiformatServiceProvider extends ServiceProvider
 {
@@ -23,7 +24,7 @@ class MultiformatServiceProvider extends ServiceProvider
                 return value(Arr::get($responses, $this->format($defaultFormat)));
             }
 
-            return value(Arr::get($responses, str_after($this->route('_format'), '.'), function () {
+            return value(Arr::get($responses, Str::after($this->route('_format'), '.'), function () {
                 abort(404);
             }));
         });

--- a/src/MultiformatServiceProvider.php
+++ b/src/MultiformatServiceProvider.php
@@ -23,7 +23,7 @@ class MultiformatServiceProvider extends ServiceProvider
                 return value(Arr::get($responses, $this->format($defaultFormat)));
             }
 
-            return value(array_get($responses, str_after($this->route('_format'), '.'), function () {
+            return value(Arr::get($responses, str_after($this->route('_format'), '.'), function () {
                 abort(404);
             }));
         });

--- a/src/MultiformatServiceProvider.php
+++ b/src/MultiformatServiceProvider.php
@@ -5,6 +5,7 @@ namespace M1guelpf\Multiformat;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Arr;
 
 class MultiformatServiceProvider extends ServiceProvider
 {
@@ -19,7 +20,7 @@ class MultiformatServiceProvider extends ServiceProvider
 
         Request::macro('match', function ($responses, $defaultFormat = 'html') {
             if ($this->route('_format') === null) {
-                return value(array_get($responses, $this->format($defaultFormat)));
+                return value(Arr::get($responses, $this->format($defaultFormat)));
             }
 
             return value(array_get($responses, str_after($this->route('_format'), '.'), function () {


### PR DESCRIPTION
Hey

The newer laravel versions have removed the array_get() which cause this package to break.
So I've removed the `array_get()` and `str_after()` in favor of the helpers `Illuminate\Support\Arr::get()` and  `Illuminate\Support\Str::after()` respectively.

**Breaking changes or changes in behavior**
None

**Changes history**
* Replaced the usage of `array_get()` with `Illuminate\Support\Arr::get()`.
* Replaced the usage of `str_get()` with `Illuminate\Support\Str::after()`.